### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -209,7 +209,13 @@ if (config.discord.inviteLink && config.discord.inviteLink.trim() !== '') {
   });
 }
 
-app.get('*', (req, res) => {
+// Rate limiter for catch-all route serving index.html
+const catchAllLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.get('*', catchAllLimiter, (req, res) => {
   if (req.path.startsWith('/api/')) {
     return res.status(404).json({ error: 'API endpoint not found' });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/faydonK/AirCodes/security/code-scanning/3](https://github.com/faydonK/AirCodes/security/code-scanning/3)

To fix the problem, we should apply a rate-limiting middleware to the catch-all GET route that serves the static file. Since `express-rate-limit` is already imported as `rateLimit`, we can create a rate limiter instance (e.g., allowing 100 requests per 15 minutes per IP) and apply it specifically to the `app.get('*', ...)` route. This ensures that requests to this endpoint are limited, mitigating the risk of DoS attacks via excessive file system access. The changes should be made in `src/server/index.js` by defining a rate limiter (if not already defined for this purpose) and applying it as middleware to the catch-all route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
